### PR TITLE
fix sigterm handling

### DIFF
--- a/faulty/serve.sh
+++ b/faulty/serve.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-gunicorn 'app:app' \
+exec gunicorn 'app:app' \
     --bind '0.0.0.0:5000' \
     --workers 1 \
     --access-logfile "-" \


### PR DESCRIPTION
faulty cannot be gracefully terminated because it does not handle sigterm properly.